### PR TITLE
support for yakuake

### DIFF
--- a/plugin/worker.h
+++ b/plugin/worker.h
@@ -4,6 +4,8 @@
 class Worker : public QObject
 {
 		Q_OBJECT
+        private:
+                QString prepareYakuake();
 
 	public:
 		static QMutex mutex;


### PR DESCRIPTION
If selected in settings, yakuake is used for running the system update commands. If yakuake is already running, the existing yakuake instance is used.