### PR TITLE
update bauerbill to use its wrapper

### DIFF
--- a/plugin/worker.cpp
+++ b/plugin/worker.cpp
@@ -61,7 +61,7 @@ QStringList Worker::getAURHelperCommands(QString AURHelper)
 
 	else if (AURHelper == "bauerbill")
 	{
-		arguments << "bauerbill" << "-Syu" << "--aur" << "--noconfirm";
+		arguments << "bb-wrapper" << "-Syu" << "--aur" << "--noconfirm";
 		return arguments;
 	}
 


### PR DESCRIPTION
Update bauerbill to bb-wrapper, without this, the updates fail with no prompt for authentication.

From the bauerbill page:

With this new version of Bauerbill I have taken a different approach that will hopefully prove both more versatile and more maintainable. Instead of trying to be a Pacman emulator that transparently wraps the AUR and ABS, this is a Powerpill extension that generates scripts to build packages. A simple wrapper script (bb-wrapper) is provided to make this transparent to the user.