### PR TITLE
pass --sudoloop to yay

### DIFF
--- a/plugin/worker.cpp
+++ b/plugin/worker.cpp
@@ -134,7 +134,7 @@ QStringList Worker::getAURHelperCommands(QString AURHelper)
 
 	else if (AURHelper == "yay")
 	{
-		arguments << "yay" << "-Syu" << "--noconfirm";
+		arguments << "yay" << "-Syu" << "--noconfirm" << "--sudoloop";
 		return arguments;
 	}
 


### PR DESCRIPTION
this avoid missing a password prompt after a long package build

I checked if other AUR providers have such an option and if it is either absent, enabled by default or set in a config file.